### PR TITLE
Fix missing | on regex that was preventing to shim correctly tree.jqu…

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ function PloneWebpackPlugin(options) {
       },
 
       jqtree: {
-        test: /jqtree\/(tree\.jquerynode|lib\/.*)(.js)?$/,
+        test: /jqtree\/(tree\.jquery|node|lib\/.*)(.js)?$/,
         loader: 'imports?jQuery=jquery,$=jquery,this=>{jQuery:$}'
       },
 


### PR DESCRIPTION
…ery JS and thus, the folder_contents and other widgets were broken.