### PR TITLE
Provide a better name for the commons chunk

### DIFF
--- a/index.js
+++ b/index.js
@@ -419,9 +419,10 @@ class PlonePlugin {
         'process.env.NODE_ENV': JSON.stringify('production')
       }),
 
-      commonschunk: new webpack.optimize.CommonsChunkPlugin(
-        'commons.' + (new Date()).getTime() + '.js'
-      ),
+      commonschunk: new webpack.optimize.CommonsChunkPlugin({
+        name: 'commons',
+        filename: 'commons.[chunkhash].js'
+      }),
 
       // Plone defaults to moment built with locales
       moment: config.momentLocales.length


### PR DESCRIPTION
It is still empty, but at least it can be cached reliably.

What was the purpose of having a cache busting there? :thinking: I mean the ``Date()`` was creating a new filename at each bundling, thus making it impossible to cache between bundlings.