### PR TITLE
Extract CSS to their own files

### DIFF
--- a/index.js
+++ b/index.js
@@ -509,9 +509,9 @@ class PlonePlugin {
       module: {
         rules: [
           this.rules.url,
-          this.rules.css,
-          this.rules.less,
-          this.rules.scss,
+          this.rules.extract.css,
+          this.rules.extract.less,
+          this.rules.extract.scss,
           this.rules.shim.ace,
           this.rules.shim.backbone,
           this.rules.shim.bootstrapalert,


### PR DESCRIPTION
Without them, at least to me, the produced bundle did not have any CSS file,
it was, more or less, embedded into the JS files, but the references to the font files were broken.

This fixes it.