### PR TITLE
Another filename fixed

### DIFF
--- a/index.js
+++ b/index.js
@@ -548,7 +548,7 @@ class PlonePlugin {
       },
       output: {
         pathinfo: true,
-        filename: 'bundle.js',
+        filename: '[name].js',
         publicPath: config.publicPath
       },
       plugins: [


### PR DESCRIPTION
If you have more than one entry point, this needs a placeholder,
otherwise more than one entry point would write to the same file.

:sweat_smile: sorry I'm also sloppy :smile: 