### PR TITLE
Revert extract CSS on their own files

### DIFF
--- a/index.js
+++ b/index.js
@@ -511,9 +511,9 @@ class PlonePlugin {
       module: {
         rules: [
           this.rules.url,
-          this.rules.extract.css,
-          this.rules.extract.less,
-          this.rules.extract.scss,
+          this.rules.css,
+          this.rules.less,
+          this.rules.scss,
           this.rules.shim.ace,
           this.rules.shim.backbone,
           this.rules.shim.bootstrapalert,


### PR DESCRIPTION
This broke webpack-dev-server.

@datakurre could you check, if you have time that is, if fonts are properly loaded? I added this because on the development mode fonts were not loaded (the Plone toolbar had no single icon).

As requested on #10 